### PR TITLE
Test for TypeError with PHP 7

### DIFF
--- a/tests/PubSubTest.php
+++ b/tests/PubSubTest.php
@@ -5,7 +5,8 @@ use studio24\PubSub\PubSub;
 class PubSubTest extends PHPUnit_Framework_TestCase {
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @requires PHP 7.0
+     * @expectedException TypeError
      */
     public function testException()
     {


### PR DESCRIPTION
PHP 7 throws a TypeError if a function is not passed. It makes more
sense to test for this than a PHPUnit_Framework_Error as this can
appear at runtime.
